### PR TITLE
🚀 4단계 - Controller 메서드 인자 매핑

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@
 
 ## 4단계 요구사항
 
-[] 학습 테스트를 
-[] Controller 메서드의 인자 타입에 따라 자동 으로 형변환 후 맵핑
+[x] 학습 테스트를 
+[x] Controller 메서드의 인자 타입에 따라 자동 으로 형변환 후 맵핑
     - [x] compilerArgs 옵션을 생성해서 메서드 파라미터를 가져올 수 있게 적용합니다.
-    - [] HandlerMethodArgumentResolver에 기능 추가를 합니다.
+    - [x] HandlerMethodArgumentResolver에 기능 추가를 합니다.
         - Resolvers들을 Registry 형태로 생성합니다.
             - primitive type에 대한 지원을 추가합니다.
             - 객체 타입에 대한 지원을 추가합니다.

--- a/README.md
+++ b/README.md
@@ -70,16 +70,15 @@
 
 [] 학습 테스트를 
 [] Controller 메서드의 인자 타입에 따라 자동 으로 형변환 후 맵핑
-    - [] compilerArgs 옵션을 생성해서 메서드 파라미터를 가져올 수 있게 적용합니다.
+    - [x] compilerArgs 옵션을 생성해서 메서드 파라미터를 가져올 수 있게 적용합니다.
     - [] HandlerMethodArgumentResolver에 기능 추가를 합니다.
         - Resolvers들을 Registry 형태로 생성합니다.
             - primitive type에 대한 지원을 추가합니다.
             - 객체 타입에 대한 지원을 추가합니다.
             - 기본적인 Wrapper class에 대한 지원을 추가합니다.
-    - [] PathPatternParser를 이용해서 PathVariable 구현을 위한 기능을 추가합니다.
+    - [x] PathPatternParser를 이용해서 PathVariable 구현을 위한 기능을 추가합니다.
         - 기능
             - URL 매칭과 경로에서 변수를 추출한다.
         - 조건
             - "/users/{id}"
             - "/users/{id}/otherResource/{resourceId}" 와 같은 포맷을 지원한다.
-    - [] build.gradle 에 compileJava 옵션으로 메서드 파라미터명을 가져올 수 있도록 변경한다.

--- a/README.md
+++ b/README.md
@@ -65,3 +65,21 @@
     - [x] /api/user 컨트롤러를 추가하고 정상 동작 테스트한다.
     - [x] model 데이터 값에 다른 반환형태를 달리한다.
     - [x] ContentType은 Application_JSON_UTF8_VALUE 로 변경한다.
+
+## 4단계 요구사항
+
+[] 학습 테스트를 
+[] Controller 메서드의 인자 타입에 따라 자동 으로 형변환 후 맵핑
+    - [] compilerArgs 옵션을 생성해서 메서드 파라미터를 가져올 수 있게 적용합니다.
+    - [] HandlerMethodArgumentResolver에 기능 추가를 합니다.
+        - Resolvers들을 Registry 형태로 생성합니다.
+            - primitive type에 대한 지원을 추가합니다.
+            - 객체 타입에 대한 지원을 추가합니다.
+            - 기본적인 Wrapper class에 대한 지원을 추가합니다.
+    - [] PathPatternParser를 이용해서 PathVariable 구현을 위한 기능을 추가합니다.
+        - 기능
+            - URL 매칭과 경로에서 변수를 추출한다.
+        - 조건
+            - "/users/{id}"
+            - "/users/{id}/otherResource/{resourceId}" 와 같은 포맷을 지원한다.
+    - [] build.gradle 에 compileJava 옵션으로 메서드 파라미터명을 가져올 수 있도록 변경한다.

--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@
             - primitive type에 대한 지원을 추가합니다.
             - 객체 타입에 대한 지원을 추가합니다.
             - 기본적인 Wrapper class에 대한 지원을 추가합니다.
+            - HttpServletRequest와 HttpServletResponse를 지원한다.
     - [x] PathPatternParser를 이용해서 PathVariable 구현을 위한 기능을 추가합니다.
         - 기능
             - URL 매칭과 경로에서 변수를 추출한다.
         - 조건
             - "/users/{id}"
             - "/users/{id}/otherResource/{resourceId}" 와 같은 포맷을 지원한다.
+    - [x] Resolver를 MethodMapping 할때, 알맞은 args를 넘겨주도록 사용합니다.

--- a/app/src/main/java/camp/nextstep/DispatcherServlet.java
+++ b/app/src/main/java/camp/nextstep/DispatcherServlet.java
@@ -7,6 +7,7 @@ import com.interface21.webmvc.servlet.mvc.tobe.AnnotationHandlerMapping;
 import com.interface21.webmvc.servlet.mvc.tobe.HandlerAdapter;
 import com.interface21.webmvc.servlet.mvc.tobe.MappingRegistry;
 import com.interface21.webmvc.servlet.mvc.tobe.exception.NotFoundException;
+import com.interface21.webmvc.servlet.mvc.tobe.parameter.config.ResolverRegistryConfig;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -31,7 +32,8 @@ public class DispatcherServlet extends HttpServlet {
     @Override
     public void init() {
         this.mappingRegistry = new HandlerMappingRegistry(
-            List.of(new AnnotationHandlerMapping(basePackages)));
+            List.of(new AnnotationHandlerMapping(ResolverRegistryConfig.getResolverRegistry(),
+                basePackages)));
         this.adapterRegistry = new HandlerAdapterRegistry(
             List.of(new AnnotationHandlerAdapter()));
 

--- a/mvc/build.gradle
+++ b/mvc/build.gradle
@@ -13,6 +13,9 @@ java {
 repositories {
     mavenCentral()
 }
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs << '-parameters'
+}
 
 dependencies {
     implementation 'jakarta.servlet:jakarta.servlet-api:5.0.0'

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/AnnotationHandlerMapping.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/AnnotationHandlerMapping.java
@@ -2,6 +2,7 @@ package com.interface21.webmvc.servlet.mvc.tobe;
 
 import com.interface21.web.bind.annotation.RequestMethod;
 import com.interface21.webmvc.servlet.mvc.tobe.meta.ControllerScanner;
+import com.interface21.webmvc.servlet.mvc.tobe.parameter.ResolverRegistry;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,9 +14,10 @@ public class AnnotationHandlerMapping implements HandlerMapping {
     private final ControllerScanner controllerScanner;
     private final Object[] basePackages;
 
-    public AnnotationHandlerMapping(final Object... basePackage) {
+
+    public AnnotationHandlerMapping(ResolverRegistry methodArgumentResolverRegistry, final Object... basePackage) {
         this.basePackages = basePackage;
-        this.controllerScanner = new ControllerScanner();
+        this.controllerScanner = new ControllerScanner(methodArgumentResolverRegistry);
     }
 
     public void initialize() {
@@ -27,7 +29,6 @@ public class AnnotationHandlerMapping implements HandlerMapping {
     public Object getHandler(final HttpServletRequest request) {
         HandlerKey key = HandlerKey.of(request.getRequestURI(),
             RequestMethod.from(request.getMethod()));
-
         return controllerScanner.get(key);
     }
 }

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/HandlerExecution.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/HandlerExecution.java
@@ -11,6 +11,7 @@ import java.rmi.registry.Registry;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -19,7 +20,7 @@ public class HandlerExecution {
     private final Object handler;
     private final Method method;
     private final ResolverRegistry registry;
-    private Map<Method, Object[]> args = new HashMap<>();
+    private Object[] resolvedParamters;
 
     public HandlerExecution(Object handler, Method method, ResolverRegistry registry) {
         this.handler = handler;
@@ -34,17 +35,18 @@ public class HandlerExecution {
     }
 
     private Object[] resolveArguments(HttpServletRequest request, HttpServletResponse response) {
-        if (args.isEmpty()) {
-            initializeArgs(request, response);
+        if (Objects.nonNull(resolvedParamters)) {
+            return resolvedParamters;
         }
 
-        return args.get(method);
+        return initializeArgs(request, response);
     }
 
-    private void initializeArgs(HttpServletRequest request, HttpServletResponse response) {
+    private Object[] initializeArgs(HttpServletRequest request, HttpServletResponse response) {
         Object[] objects = Arrays.stream(method.getParameters())
             .map(parameter -> registry.resolve(parameter, request, response))
             .toArray();
-        args.put(method, objects);
+        resolvedParamters = objects;
+        return objects;
     }
 }

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/HandlerExecution.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/HandlerExecution.java
@@ -29,8 +29,8 @@ public class HandlerExecution {
 
     public ModelAndView handle(final HttpServletRequest request, final HttpServletResponse response)
         throws Exception {
-
-        return (ModelAndView) method.invoke(handler, request, response);
+        Object[] args = resolveArguments(request, response);
+        return (ModelAndView) method.invoke(handler, args);
     }
 
     private Object[] resolveArguments(HttpServletRequest request, HttpServletResponse response) {
@@ -44,7 +44,7 @@ public class HandlerExecution {
     private void initializeArgs(HttpServletRequest request, HttpServletResponse response) {
         Object[] objects = Arrays.stream(method.getParameters())
             .map(parameter -> registry.resolve(parameter, request, response))
-                .toArray();
+            .toArray();
         args.put(method, objects);
     }
 }

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/HandlerExecution.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/HandlerExecution.java
@@ -1,22 +1,50 @@
 package com.interface21.webmvc.servlet.mvc.tobe;
 
 import com.interface21.webmvc.servlet.ModelAndView;
+import com.interface21.webmvc.servlet.mvc.tobe.parameter.MethodArgumentResolverRegistry;
+import com.interface21.webmvc.servlet.mvc.tobe.parameter.ResolverRegistry;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.rmi.registry.Registry;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 public class HandlerExecution {
 
     private final Object handler;
     private final Method method;
+    private final ResolverRegistry registry;
+    private Map<Method, Object[]> args = new HashMap<>();
 
-    public HandlerExecution(Object handler, Method method) {
+    public HandlerExecution(Object handler, Method method, ResolverRegistry registry) {
         this.handler = handler;
         this.method = method;
+        this.registry = registry;
     }
 
     public ModelAndView handle(final HttpServletRequest request, final HttpServletResponse response)
         throws Exception {
+
         return (ModelAndView) method.invoke(handler, request, response);
+    }
+
+    private Object[] resolveArguments(HttpServletRequest request, HttpServletResponse response) {
+        if (args.isEmpty()) {
+            initializeArgs(request, response);
+        }
+
+        return args.get(method);
+    }
+
+    private void initializeArgs(HttpServletRequest request, HttpServletResponse response) {
+        Object[] objects = Arrays.stream(method.getParameters())
+            .map(parameter -> registry.resolve(parameter, request, response))
+                .toArray();
+        args.put(method, objects);
     }
 }

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/HandlerKey.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/HandlerKey.java
@@ -1,6 +1,7 @@
 package com.interface21.webmvc.servlet.mvc.tobe;
 
 import com.interface21.web.bind.annotation.RequestMethod;
+import com.interface21.webmvc.servlet.mvc.tobe.support.PathPatternUtil;
 import java.util.Objects;
 
 public class HandlerKey {
@@ -15,6 +16,11 @@ public class HandlerKey {
 
     public static HandlerKey of(final String url, final RequestMethod requestMethod) {
         return new HandlerKey(url, requestMethod);
+    }
+
+    public boolean matches(HandlerKey handlerKey) {
+        return PathPatternUtil.isUrlMatch(this.url, handlerKey.url) ||
+            this.equals(handlerKey);
     }
 
     @Override

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/meta/ControllerScanner.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/meta/ControllerScanner.java
@@ -5,6 +5,7 @@ import com.interface21.web.bind.annotation.RequestMapping;
 import com.interface21.webmvc.servlet.mvc.tobe.HandlerExecution;
 import com.interface21.webmvc.servlet.mvc.tobe.HandlerKey;
 import com.interface21.webmvc.servlet.mvc.tobe.exception.ControllerInitializationException;
+import com.interface21.webmvc.servlet.mvc.tobe.exception.NotFoundException;
 import com.interface21.webmvc.servlet.mvc.tobe.parameter.ResolverRegistry;
 import com.interface21.webmvc.servlet.mvc.tobe.support.ReflectionUtils;
 import java.lang.reflect.InvocationTargetException;
@@ -100,7 +101,7 @@ public class ControllerScanner {
                     .filter(key -> key.matches(handlerKey))
                     .findFirst()
                 .map(key -> handlerExecutions.get(key))
-                .orElse(null);
+                .orElseThrow(() -> new NotFoundException("지원하지 않는 url 과 method 입니다."));
 
     }
 }

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/meta/ControllerScanner.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/meta/ControllerScanner.java
@@ -5,8 +5,6 @@ import com.interface21.web.bind.annotation.RequestMapping;
 import com.interface21.webmvc.servlet.mvc.tobe.HandlerExecution;
 import com.interface21.webmvc.servlet.mvc.tobe.HandlerKey;
 import com.interface21.webmvc.servlet.mvc.tobe.exception.ControllerInitializationException;
-import com.interface21.webmvc.servlet.mvc.tobe.exception.NotFoundException;
-import com.interface21.webmvc.servlet.mvc.tobe.parameter.MethodArgumentResolverRegistry;
 import com.interface21.webmvc.servlet.mvc.tobe.parameter.ResolverRegistry;
 import com.interface21.webmvc.servlet.mvc.tobe.support.ReflectionUtils;
 import java.lang.reflect.InvocationTargetException;

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/meta/ControllerScanner.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/meta/ControllerScanner.java
@@ -45,7 +45,7 @@ public class ControllerScanner {
                 Collector.of(
                     HashMap::new,  //supplier
                     (acc, method) -> createHandlerKeys(controllerUri, method)  // accumulator
-                        .forEach(key -> acc.put(key, new HandlerExecution(instance, method, resolverRegistry))),
+                        .forEach(key -> acc.put(key, new HandlerExecution(instance, method, resolverRegistry.addResolver(controllerUri)))),
                     (acc1, acc2) -> { // combiner
                         acc1.putAll(acc2);
                         return acc1;

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/HttpServletRequestResolver.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/HttpServletRequestResolver.java
@@ -1,0 +1,18 @@
+package com.interface21.webmvc.servlet.mvc.tobe.parameter;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.lang.reflect.Parameter;
+
+public class HttpServletRequestResolver implements ParameterResolver{
+
+    @Override
+    public boolean support(Parameter parameter) {
+        return HttpServletRequest.class.isAssignableFrom(parameter.getType());
+    }
+
+    @Override
+    public Object parseValue(Parameter parameter, HttpServletRequest request, HttpServletResponse response) {
+        return request;
+    }
+}

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/HttpServletResponseResolver.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/HttpServletResponseResolver.java
@@ -1,0 +1,19 @@
+package com.interface21.webmvc.servlet.mvc.tobe.parameter;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.lang.reflect.Parameter;
+
+public class HttpServletResponseResolver implements ParameterResolver{
+
+    @Override
+    public boolean support(Parameter parameter) {
+        return HttpServletResponse.class
+            .isAssignableFrom(parameter.getType());
+    }
+
+    @Override
+    public Object parseValue(Parameter parameter, HttpServletRequest request, HttpServletResponse response) {
+        return response;
+    }
+}

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/MethodArgumentResolverRegistry.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/MethodArgumentResolverRegistry.java
@@ -1,0 +1,35 @@
+package com.interface21.webmvc.servlet.mvc.tobe.parameter;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.lang.reflect.Parameter;
+import java.util.List;
+
+public class MethodArgumentResolverRegistry implements ResolverRegistry {
+
+    private final List<ParameterResolver> parameterResolvers;
+    private final ParameterResolver defaultParameterResolver;
+
+    public MethodArgumentResolverRegistry(List<ParameterResolver> parameterResolvers,
+        ParameterResolver defaultParameterResolver) {
+        this.parameterResolvers = parameterResolvers;
+        this.defaultParameterResolver = defaultParameterResolver;
+    }
+
+    @Override
+    public Object resolve(Parameter parameter, HttpServletRequest request,
+        HttpServletResponse response) {
+
+        return parameterResolvers.stream()
+            .filter(parameterResolver -> parameterResolver.support(parameter))
+            .findFirst()
+            .orElse(defaultParameterResolver)
+            .parseValue(parameter, request, response);
+    }
+
+    @Override
+    public ResolverRegistry addResolver(String url) {
+        parameterResolvers.add(new PathVariableParameterResolver(url));
+        return this;
+    }
+}

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/MethodArgumentResolverRegistry.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/MethodArgumentResolverRegistry.java
@@ -5,7 +5,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.lang.reflect.Parameter;
 import java.util.List;
 
-public class MethodArgumentResolverRegistry implements ResolverRegistry {
+public final class MethodArgumentResolverRegistry implements ResolverRegistry {
 
     private final List<ParameterResolver> parameterResolvers;
     private final ParameterResolver defaultParameterResolver;

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/MethodArgumentResolverRegistry.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/MethodArgumentResolverRegistry.java
@@ -29,7 +29,13 @@ public final class MethodArgumentResolverRegistry implements ResolverRegistry {
 
     @Override
     public ResolverRegistry addResolver(String url) {
-        parameterResolvers.add(new PathVariableParameterResolver(url));
+        parameterResolvers.stream()
+            .filter(resolver -> resolver.getClass() == PathVariableParameterResolver.class)
+            .forEach(
+                resolver -> ((PathVariableParameterResolver) resolver)
+                    .addPathVariableParamater(url)
+            );
+
         return this;
     }
 }

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/ObjectParameterResolver.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/ObjectParameterResolver.java
@@ -1,0 +1,44 @@
+package com.interface21.webmvc.servlet.mvc.tobe.parameter;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
+
+public class ObjectParameterResolver implements ParameterResolver {
+
+
+    @Override
+    public boolean support(Parameter parameter) {
+        return false;
+    }
+
+    @Override
+    public Object parseValue(Parameter parameter, HttpServletRequest request,
+        HttpServletResponse response) {
+        Class<?> clazz = parameter.getType();
+        try {
+            Object instance = clazz.getDeclaredConstructor().newInstance();
+
+            Arrays.stream(clazz.getDeclaredFields())
+                .forEach(
+                    field -> {
+                        field.setAccessible(true);
+                        Object fieldValue = request.getParameter(field.getName());
+                        try {
+                            field.set(instance, TypeMapper.parse(field.getType(), fieldValue));
+                        } catch (IllegalAccessException e) {
+                            throw new RuntimeException("field에 대해 접근 권한이 없습니다.");
+                        }
+                    }
+                );
+            return instance;
+
+
+        } catch (NoSuchMethodException | InvocationTargetException | InstantiationException |
+                 IllegalAccessException e) {
+            throw new RuntimeException("객체 파싱을 실패하였습니다..");
+        }
+    }
+}

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/ParameterResolver.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/ParameterResolver.java
@@ -8,5 +8,5 @@ public interface ParameterResolver {
 
     boolean support(Parameter parameter);
 
-    Object parseValue(HttpServletRequest request, HttpServletResponse response);
+    Object parseValue(Parameter parameter, HttpServletRequest request, HttpServletResponse response);
 }

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/ParameterResolver.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/ParameterResolver.java
@@ -1,0 +1,12 @@
+package com.interface21.webmvc.servlet.mvc.tobe.parameter;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.lang.reflect.Parameter;
+
+public interface ParameterResolver {
+
+    boolean support(Parameter parameter);
+
+    Object parseValue(HttpServletRequest request, HttpServletResponse response);
+}

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/PathVariableParameterResolver.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/PathVariableParameterResolver.java
@@ -1,0 +1,33 @@
+package com.interface21.webmvc.servlet.mvc.tobe.parameter;
+
+import com.interface21.web.bind.annotation.PathVariable;
+import com.interface21.webmvc.servlet.mvc.tobe.support.PathPatternUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.lang.reflect.Parameter;
+
+public class PathVariableParameterResolver implements ParameterResolver {
+
+    private final String url;
+
+    public PathVariableParameterResolver(String pathVariableUrls) {
+        url = pathVariableUrls;
+    }
+
+    @Override
+    public boolean support(Parameter parameter) {
+        return parameter.isAnnotationPresent(PathVariable.class);
+    }
+
+    @Override
+    public Object parseValue(Parameter parameter, HttpServletRequest request,
+        HttpServletResponse response) {
+        String variableName = parameter.getAnnotation(PathVariable.class)
+            .value();
+
+        String requestUri = request.getRequestURI();
+        String variableValues = PathPatternUtil.getUriValue(url, requestUri, variableName);
+
+        return TypeMapper.parse(parameter.getType(), variableValues);
+    }
+}

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/PathVariableParameterResolver.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/PathVariableParameterResolver.java
@@ -5,6 +5,7 @@ import com.interface21.webmvc.servlet.mvc.tobe.support.PathPatternUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.lang.reflect.Parameter;
+import java.util.Optional;
 
 public class PathVariableParameterResolver implements ParameterResolver {
 
@@ -24,6 +25,10 @@ public class PathVariableParameterResolver implements ParameterResolver {
         HttpServletResponse response) {
         String variableName = parameter.getAnnotation(PathVariable.class)
             .value();
+
+        if(variableName.isEmpty()){
+            variableName = parameter.getName();
+        }
 
         String requestUri = request.getRequestURI();
         String variableValues = PathPatternUtil.getUriValue(url, requestUri, variableName);

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/ResolverRegistry.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/ResolverRegistry.java
@@ -7,4 +7,6 @@ import java.lang.reflect.Parameter;
 public interface ResolverRegistry {
 
     Object resolve(Parameter parameter, HttpServletRequest request, HttpServletResponse response);
+
+    ResolverRegistry addResolver(String url);
 }

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/ResolverRegistry.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/ResolverRegistry.java
@@ -1,0 +1,10 @@
+package com.interface21.webmvc.servlet.mvc.tobe.parameter;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.lang.reflect.Parameter;
+
+public interface ResolverRegistry {
+
+    Object resolve(Parameter parameter, HttpServletRequest request, HttpServletResponse response);
+}

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/TypeArgumentResolver.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/TypeArgumentResolver.java
@@ -8,12 +8,18 @@ public class TypeArgumentResolver implements ParameterResolver {
 
     @Override
     public boolean support(Parameter parameter) {
-        return false;
+        return TypeMapper
+            .getParser(parameter.getType())
+            .isPresent();
     }
 
     @Override
     public Object parseValue(Parameter parameter, HttpServletRequest request,
         HttpServletResponse response) {
-        return null;
+
+        String paramName = request.getParameter(parameter.getName());
+        Object fieldValue = request.getParameter(paramName);
+
+        return TypeMapper.parse(parameter.getType(), fieldValue);
     }
 }

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/TypeArgumentResolver.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/TypeArgumentResolver.java
@@ -17,8 +17,7 @@ public class TypeArgumentResolver implements ParameterResolver {
     public Object parseValue(Parameter parameter, HttpServletRequest request,
         HttpServletResponse response) {
 
-        String paramName = request.getParameter(parameter.getName());
-        Object fieldValue = request.getParameter(paramName);
+        Object fieldValue = request.getParameter(parameter.getName());
 
         return TypeMapper.parse(parameter.getType(), fieldValue);
     }

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/TypeArgumentResolver.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/TypeArgumentResolver.java
@@ -1,0 +1,19 @@
+package com.interface21.webmvc.servlet.mvc.tobe.parameter;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.lang.reflect.Parameter;
+
+public class TypeArgumentResolver implements ParameterResolver {
+
+    @Override
+    public boolean support(Parameter parameter) {
+        return false;
+    }
+
+    @Override
+    public Object parseValue(Parameter parameter, HttpServletRequest request,
+        HttpServletResponse response) {
+        return null;
+    }
+}

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/TypeMapper.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/TypeMapper.java
@@ -1,0 +1,38 @@
+package com.interface21.webmvc.servlet.mvc.tobe.parameter;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+public final class TypeMapper {
+
+    private static Map<Class<?>, Function<String, ?>> typeToParser;
+
+    private TypeMapper() {
+
+    }
+
+    public static Optional<Function<String, ?>> getParser(Class<?> clazz) {
+        if (typeToParser == null) {
+            createTypeToParser();
+        }
+
+        return Optional.ofNullable(typeToParser.get(clazz));
+    }
+
+    public static Object parse(Class<?> targetType, Object requestValue){
+        return getParser(targetType).orElseThrow(() -> new IllegalArgumentException("지원하지 않는 형식의 데이터 형식입니다."))
+            .apply((String) requestValue);
+    }
+
+    public static void createTypeToParser() {
+        typeToParser.put(long.class, Boolean::parseBoolean);
+        typeToParser.put(Long.class, Long::parseLong);
+        typeToParser.put(String.class, s -> s);
+        typeToParser.put(boolean.class, Boolean::parseBoolean);
+        typeToParser.put(Boolean.class, Boolean::parseBoolean);
+        typeToParser.put(int.class, Integer::parseInt);
+        typeToParser.put(Integer.class, Integer::parseInt);
+    }
+
+}

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/TypeMapper.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/TypeMapper.java
@@ -1,5 +1,6 @@
 package com.interface21.webmvc.servlet.mvc.tobe.parameter;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -26,7 +27,8 @@ public final class TypeMapper {
     }
 
     public static void createTypeToParser() {
-        typeToParser.put(long.class, Boolean::parseBoolean);
+        typeToParser = new HashMap<>();
+        typeToParser.put(long.class, Long::parseLong);
         typeToParser.put(Long.class, Long::parseLong);
         typeToParser.put(String.class, s -> s);
         typeToParser.put(boolean.class, Boolean::parseBoolean);

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/TypeMapper.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/TypeMapper.java
@@ -1,40 +1,35 @@
 package com.interface21.webmvc.servlet.mvc.tobe.parameter;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
 public final class TypeMapper {
 
-    private static Map<Class<?>, Function<String, ?>> typeToParser;
+    private final static Map<Class<?>, Function<String, ?>> typeToParser
+        = Map.of(
+        long.class, Long::parseLong,
+        Long.class, Long::parseLong,
+        String.class, s -> s,
+        boolean.class, Boolean::parseBoolean,
+        Boolean.class, Boolean::parseBoolean,
+        int.class, Integer::parseInt,
+        Integer.class, Integer::parseInt
+    );
 
     private TypeMapper() {
-
     }
 
     public static Optional<Function<String, ?>> getParser(Class<?> clazz) {
-        if (typeToParser == null) {
-            createTypeToParser();
-        }
 
         return Optional.ofNullable(typeToParser.get(clazz));
     }
 
-    public static Object parse(Class<?> targetType, Object requestValue){
-        return getParser(targetType).orElseThrow(() -> new IllegalArgumentException("지원하지 않는 형식의 데이터 형식입니다."))
+    public static Object parse(Class<?> targetType, Object requestValue) {
+        return getParser(targetType).orElseThrow(
+                () -> new IllegalArgumentException("지원하지 않는 형식의 데이터 형식입니다."))
             .apply((String) requestValue);
     }
 
-    public static void createTypeToParser() {
-        typeToParser = new HashMap<>();
-        typeToParser.put(long.class, Long::parseLong);
-        typeToParser.put(Long.class, Long::parseLong);
-        typeToParser.put(String.class, s -> s);
-        typeToParser.put(boolean.class, Boolean::parseBoolean);
-        typeToParser.put(Boolean.class, Boolean::parseBoolean);
-        typeToParser.put(int.class, Integer::parseInt);
-        typeToParser.put(Integer.class, Integer::parseInt);
-    }
 
 }

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/config/Configuration.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/config/Configuration.java
@@ -1,0 +1,13 @@
+package com.interface21.webmvc.servlet.mvc.tobe.parameter.config;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Configuration {
+
+}

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/config/ResolverRegistryConfig.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/config/ResolverRegistryConfig.java
@@ -5,22 +5,19 @@ import com.interface21.webmvc.servlet.mvc.tobe.parameter.HttpServletResponseReso
 import com.interface21.webmvc.servlet.mvc.tobe.parameter.MethodArgumentResolverRegistry;
 import com.interface21.webmvc.servlet.mvc.tobe.parameter.ObjectParameterResolver;
 import com.interface21.webmvc.servlet.mvc.tobe.parameter.ParameterResolver;
-import com.interface21.webmvc.servlet.mvc.tobe.parameter.PathVariableParameterResolver;
 import com.interface21.webmvc.servlet.mvc.tobe.parameter.ResolverRegistry;
 import com.interface21.webmvc.servlet.mvc.tobe.parameter.TypeArgumentResolver;
 import java.util.List;
-import javax.naming.spi.Resolver;
 
 @Configuration
 public final class ResolverRegistryConfig {
 
+    public static ResolverRegistry REGISTRY;
     private static List<ParameterResolver> RESOLVERS;
     private static ParameterResolver DEFAULT;
 
-    public static ResolverRegistry REGISTRY;
-
-    public static ResolverRegistry getResolverRegistry(){
-        if (REGISTRY == null){
+    public static ResolverRegistry getResolverRegistry() {
+        if (REGISTRY == null) {
             REGISTRY = new MethodArgumentResolverRegistry(getResolvers(), getDefaultResolver());
         }
         return REGISTRY;
@@ -28,8 +25,9 @@ public final class ResolverRegistryConfig {
 
     public static List<ParameterResolver> getResolvers() {
         if (RESOLVERS == null) {
-            RESOLVERS = List.of(new HttpServletRequestResolver(), new HttpServletResponseResolver(),
-                new PathVariableParameterResolver(), new TypeArgumentResolver());
+
+            RESOLVERS = List.of(new HttpServletRequestResolver()
+                , new HttpServletResponseResolver(), new TypeArgumentResolver());
         }
 
         return RESOLVERS;

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/config/ResolverRegistryConfig.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/config/ResolverRegistryConfig.java
@@ -1,0 +1,45 @@
+package com.interface21.webmvc.servlet.mvc.tobe.parameter.config;
+
+import com.interface21.webmvc.servlet.mvc.tobe.parameter.HttpServletRequestResolver;
+import com.interface21.webmvc.servlet.mvc.tobe.parameter.HttpServletResponseResolver;
+import com.interface21.webmvc.servlet.mvc.tobe.parameter.MethodArgumentResolverRegistry;
+import com.interface21.webmvc.servlet.mvc.tobe.parameter.ObjectParameterResolver;
+import com.interface21.webmvc.servlet.mvc.tobe.parameter.ParameterResolver;
+import com.interface21.webmvc.servlet.mvc.tobe.parameter.PathVariableParameterResolver;
+import com.interface21.webmvc.servlet.mvc.tobe.parameter.ResolverRegistry;
+import com.interface21.webmvc.servlet.mvc.tobe.parameter.TypeArgumentResolver;
+import java.util.List;
+import javax.naming.spi.Resolver;
+
+@Configuration
+public final class ResolverRegistryConfig {
+
+    private static List<ParameterResolver> RESOLVERS;
+    private static ParameterResolver DEFAULT;
+
+    public static ResolverRegistry REGISTRY;
+
+    public static ResolverRegistry getResolverRegistry(){
+        if (REGISTRY == null){
+            REGISTRY = new MethodArgumentResolverRegistry(getResolvers(), getDefaultResolver());
+        }
+        return REGISTRY;
+    }
+
+    public static List<ParameterResolver> getResolvers() {
+        if (RESOLVERS == null) {
+            RESOLVERS = List.of(new HttpServletRequestResolver(), new HttpServletResponseResolver(),
+                new PathVariableParameterResolver(), new TypeArgumentResolver());
+        }
+
+        return RESOLVERS;
+    }
+
+    public static ParameterResolver getDefaultResolver() {
+        if (DEFAULT == null) {
+            DEFAULT = new ObjectParameterResolver();
+        }
+
+        return DEFAULT;
+    }
+}

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/config/ResolverRegistryConfig.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/config/ResolverRegistryConfig.java
@@ -7,6 +7,8 @@ import com.interface21.webmvc.servlet.mvc.tobe.parameter.ObjectParameterResolver
 import com.interface21.webmvc.servlet.mvc.tobe.parameter.ParameterResolver;
 import com.interface21.webmvc.servlet.mvc.tobe.parameter.ResolverRegistry;
 import com.interface21.webmvc.servlet.mvc.tobe.parameter.TypeArgumentResolver;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 @Configuration
@@ -26,8 +28,8 @@ public final class ResolverRegistryConfig {
     public static List<ParameterResolver> getResolvers() {
         if (RESOLVERS == null) {
 
-            RESOLVERS = List.of(new HttpServletRequestResolver()
-                , new HttpServletResponseResolver(), new TypeArgumentResolver());
+            RESOLVERS = new ArrayList<>(Arrays.asList(new HttpServletRequestResolver()
+                , new HttpServletResponseResolver(), new TypeArgumentResolver()));
         }
 
         return RESOLVERS;

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/support/PathPatternParser.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/support/PathPatternParser.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class PathPatternParser {
+public final class PathPatternParser {
 
     private final Pattern pattern;
     private final List<String> variableNames = new ArrayList<>();

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/support/PathPatternParser.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/support/PathPatternParser.java
@@ -1,8 +1,11 @@
 package com.interface21.webmvc.servlet.mvc.tobe.support;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class PathPatternParser {
@@ -16,14 +19,29 @@ public class PathPatternParser {
     }
 
     private String buildRegex(String pattern) {
-        return null;
+        Matcher matcher = Pattern.compile("\\{([^}]+)}").matcher(pattern);
+        StringBuffer buffer = new StringBuffer();
+        while (matcher.find()) {
+            variableNames.add(matcher.group(1));
+            matcher.appendReplacement(buffer, "([^/]+)");
+        }
+        matcher.appendTail(buffer);
+        return buffer.toString();
     }
 
     public boolean matches(String path) {
-        return false;
+        return pattern.matcher(path).matches();
     }
 
     public Map<String, String> extractUriVariables(String path) {
-        return null;
+        Matcher matcher = pattern.matcher(path);
+        if (!matcher.matches()) {
+            return Collections.emptyMap();
+        }
+        Map<String, String> variables = new HashMap<>();
+        for (int i = 0; i < variableNames.size(); i++) {
+            variables.put(variableNames.get(i), matcher.group(i + 1));
+        }
+        return variables;
     }
 }

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/support/PathPatternUtil.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/support/PathPatternUtil.java
@@ -5,14 +5,20 @@ import java.util.Map;
 public class PathPatternUtil {
 
     public static String getUriValue(String pattern, String path, String key) {
-        return null;
+        final Map<String, String> uriVariables = getUriVariables(pattern, path);
+        return uriVariables.get(key);
     }
 
     public static Map<String, String> getUriVariables(String pattern, String path) {
-        return null;
+        if (!isUrlMatch(pattern, path)) {
+            return Map.of();
+        }
+        final PathPatternParser parser = new PathPatternParser(pattern);
+        return parser.extractUriVariables(path);
     }
 
     public static boolean isUrlMatch(String pattern, String path) {
-        return false;
+        final PathPatternParser parser = new PathPatternParser(pattern);
+        return parser.matches(path);
     }
 }

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/support/PathPatternUtil.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/support/PathPatternUtil.java
@@ -2,7 +2,7 @@ package com.interface21.webmvc.servlet.mvc.tobe.support;
 
 import java.util.Map;
 
-public class PathPatternUtil {
+public final class PathPatternUtil {
 
     public static String getUriValue(String pattern, String path, String key) {
         final Map<String, String> uriVariables = getUriVariables(pattern, path);

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/support/ReflectionUtils.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/support/ReflectionUtils.java
@@ -4,7 +4,7 @@ import java.lang.annotation.Annotation;
 import java.util.Set;
 import org.reflections.Reflections;
 
-public class ReflectionUtils {
+public final class ReflectionUtils {
 
     public static Set<Class<?>> getAnnotatedClass(Object[] basePackages,
         Class<? extends Annotation> clazz) {

--- a/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/FailAnnotationHandlerMappingTest.java
+++ b/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/FailAnnotationHandlerMappingTest.java
@@ -4,6 +4,7 @@ package com.interface21.webmvc.servlet.mvc.tobe;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.interface21.webmvc.servlet.mvc.tobe.exception.ControllerInitializationException;
+import com.interface21.webmvc.servlet.mvc.tobe.parameter.config.ResolverRegistryConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -13,7 +14,7 @@ public class FailAnnotationHandlerMappingTest {
     @DisplayName("Controller가 생성자가 Private이면, Mapping Initialization가 실패합니다.")
     void get() {
 
-        assertThatThrownBy(() -> new AnnotationHandlerMapping("noconstructor").initialize())
+        assertThatThrownBy(() -> new AnnotationHandlerMapping(ResolverRegistryConfig.getResolverRegistry(),"noconstructor").initialize())
             .isInstanceOf(ControllerInitializationException.class);
     }
 }

--- a/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/meta/ControllerScannerTest.java
+++ b/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/meta/ControllerScannerTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.interface21.web.bind.annotation.RequestMethod;
 import com.interface21.webmvc.servlet.mvc.tobe.HandlerExecution;
 import com.interface21.webmvc.servlet.mvc.tobe.HandlerKey;
+import com.interface21.webmvc.servlet.mvc.tobe.parameter.config.ResolverRegistryConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -13,7 +14,9 @@ class ControllerScannerTest {
     @Test
     @DisplayName("ControllerScanner가 @Controller 클래스들을 가져와서 Mapping을 생성합니다.")
     void get() {
-        ControllerScanner controllerScanner = new ControllerScanner();
+
+        ControllerScanner controllerScanner = new ControllerScanner(
+            ResolverRegistryConfig.getResolverRegistry());
         controllerScanner.initialize("samples");
 
         assertThat(controllerScanner.get(new HandlerKey("/no-method", RequestMethod.GET)))

--- a/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/HttpServletRequestResolverTest.java
+++ b/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/HttpServletRequestResolverTest.java
@@ -1,0 +1,52 @@
+package com.interface21.webmvc.servlet.mvc.tobe.parameter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import samples.TestController;
+
+class HttpServletRequestResolverTest {
+
+    @Test
+    @DisplayName("HttpServletRequest 지원하는지 확인한다.")
+    void support(){
+        final var request = mock(HttpServletRequest.class);
+        final var response = mock(HttpServletResponse.class);
+
+        Method method = Arrays.stream(TestController.class.getDeclaredMethods())
+            .filter(methods -> methods.getName() == "findUserId")
+            .findFirst()
+            .orElseThrow(RuntimeException::new);
+
+        Parameter parameter = method.getParameters()[0];
+        ParameterResolver resolver = new HttpServletRequestResolver();
+
+        assertThat(resolver.support(parameter))
+            .isTrue();
+    }
+    @Test
+    @DisplayName("HttpServletRequest 인수를 가진 요청에 대해 request를 반환합니다.")
+    void returnServletRequest(){
+        final var request = mock(HttpServletRequest.class);
+        final var response = mock(HttpServletResponse.class);
+
+        Method method = Arrays.stream(TestController.class.getDeclaredMethods())
+            .filter(methods -> methods.getName() == "findUserId")
+            .findFirst()
+            .orElseThrow(RuntimeException::new);
+
+        Parameter parameter = method.getParameters()[0];
+        ParameterResolver resolver = new HttpServletRequestResolver();
+
+        assertThat(resolver.parseValue(parameter, request, response))
+            .isEqualTo(request);
+    }
+
+}

--- a/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/HttpServletResponseResolverTest.java
+++ b/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/HttpServletResponseResolverTest.java
@@ -1,0 +1,50 @@
+package com.interface21.webmvc.servlet.mvc.tobe.parameter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import samples.TestController;
+
+class HttpServletResponseResolverTest {
+    @Test
+    @DisplayName("HttpServletResponse 지원하는지 확인한다.")
+    void support(){
+        final var request = mock(HttpServletRequest.class);
+        final var response = mock(HttpServletResponse.class);
+
+        Method method = Arrays.stream(TestController.class.getDeclaredMethods())
+            .filter(methods -> methods.getName() == "findUserId")
+            .findFirst()
+            .orElseThrow(RuntimeException::new);
+
+        Parameter parameter = method.getParameters()[1];
+        ParameterResolver resolver = new HttpServletResponseResolver();
+
+        assertThat(resolver.support(parameter))
+            .isTrue();
+    }
+    @Test
+    @DisplayName("HttpServletResponse 인수를 가진 요청에 대해 request를 반환합니다.")
+    void returnServletResponse(){
+        final var request = mock(HttpServletRequest.class);
+        final var response = mock(HttpServletResponse.class);
+
+        Method method = Arrays.stream(TestController.class.getDeclaredMethods())
+            .filter(methods -> methods.getName() == "findUserId")
+            .findFirst()
+            .orElseThrow(RuntimeException::new);
+
+        Parameter parameter = method.getParameters()[1];
+        ParameterResolver resolver = new HttpServletResponseResolver();
+
+        assertThat(resolver.parseValue(parameter, request, response))
+            .isEqualTo(response);
+    }
+}

--- a/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/MethodArgumentResolverRegistryTest.java
+++ b/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/MethodArgumentResolverRegistryTest.java
@@ -1,0 +1,40 @@
+package com.interface21.webmvc.servlet.mvc.tobe.parameter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.interface21.webmvc.servlet.mvc.tobe.parameter.config.ResolverRegistryConfig;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import samples.TestUserController;
+
+class MethodArgumentResolverRegistryTest {
+    @Test
+    @DisplayName("MethodArgumentResolverRegistry 지원하는지 확인한다.")
+    void support(){
+        final var request = mock(HttpServletRequest.class);
+        final var response = mock(HttpServletResponse.class);
+        when(request.getParameter("id")).thenReturn("123");
+        when(request.getParameter("age")).thenReturn("1234");
+
+        Method method = Arrays.stream(TestUserController.class.getDeclaredMethods())
+            .filter(methods -> methods.getName() == "create_int_long")
+            .findFirst()
+            .orElseThrow(RuntimeException::new);
+
+        Parameter parameter = method.getParameters()[0];
+        ResolverRegistry MethodArgumentResolverRegistry = ResolverRegistryConfig.getResolverRegistry();
+
+
+        assertThat(MethodArgumentResolverRegistry.resolve(parameter, request, response))
+            .isEqualTo(123L);
+
+    }
+}

--- a/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/ObjectParameterResolverTest.java
+++ b/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/ObjectParameterResolverTest.java
@@ -1,0 +1,62 @@
+package com.interface21.webmvc.servlet.mvc.tobe.parameter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import samples.TestUser;
+import samples.TestUserController;
+
+class ObjectParameterResolverTest {
+
+    @Test
+    @DisplayName("Object Type을  지원하는지 확인하면 실패한다.")
+    void supportFail() {
+        final var request = mock(HttpServletRequest.class);
+        final var response = mock(HttpServletResponse.class);
+
+        when(request.getParameter("userId")).thenReturn("1234");
+        when(request.getParameter("password")).thenReturn("12345");
+        when(request.getParameter("age")).thenReturn("123456");
+
+        Method method = Arrays.stream(TestUserController.class.getDeclaredMethods())
+            .filter(methods -> methods.getName() == "create_javabean")
+            .findFirst()
+            .orElseThrow(RuntimeException::new);
+
+        Parameter parameter = method.getParameters()[0];
+        ParameterResolver resolver = new ObjectParameterResolver();
+
+        assertThat(resolver.support(parameter))
+            .isFalse();
+    }
+
+    @Test
+    @DisplayName("Object Type을  지원하는지 확인한다.")
+    void returnObjectParameterParsed() {
+        final var request = mock(HttpServletRequest.class);
+        final var response = mock(HttpServletResponse.class);
+
+        when(request.getParameter("userId")).thenReturn("1234");
+        when(request.getParameter("password")).thenReturn("12345");
+        when(request.getParameter("age")).thenReturn("123456");
+
+        Method method = Arrays.stream(TestUserController.class.getDeclaredMethods())
+            .filter(methods -> methods.getName() == "create_javabean")
+            .findFirst()
+            .orElseThrow(RuntimeException::new);
+
+        Parameter parameter = method.getParameters()[0];
+        ParameterResolver resolver = new ObjectParameterResolver();
+
+        assertThat(resolver.parseValue(parameter,request, response))
+            .isEqualTo(new TestUser("1234", "12345",123456));
+    }
+}

--- a/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/ObjectParameterResolverTest.java
+++ b/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/ObjectParameterResolverTest.java
@@ -39,7 +39,7 @@ class ObjectParameterResolverTest {
     }
 
     @Test
-    @DisplayName("Object Type을  지원하는지 확인한다.")
+    @DisplayName("Object Type 인수를 가진 요청에 대해 request를 반환합니다.")
     void returnObjectParameterParsed() {
         final var request = mock(HttpServletRequest.class);
         final var response = mock(HttpServletResponse.class);

--- a/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/PathVariableParameterResolverTest.java
+++ b/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/PathVariableParameterResolverTest.java
@@ -1,7 +1,6 @@
 package com.interface21.webmvc.servlet.mvc.tobe.parameter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -12,7 +11,6 @@ import java.lang.reflect.Parameter;
 import java.util.Arrays;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import samples.TestController;
 import samples.TestUserController;
 
 class PathVariableParameterResolverTest {

--- a/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/PathVariableParameterResolverTest.java
+++ b/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/PathVariableParameterResolverTest.java
@@ -1,0 +1,54 @@
+package com.interface21.webmvc.servlet.mvc.tobe.parameter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import samples.TestController;
+import samples.TestUserController;
+
+class PathVariableParameterResolverTest {
+    @Test
+    @DisplayName("PathVariableParameter 지원하는지 확인한다.")
+    void support(){
+        final var request = mock(HttpServletRequest.class);
+        final var response = mock(HttpServletResponse.class);
+
+        Method method = Arrays.stream(TestUserController.class.getDeclaredMethods())
+            .filter(methods -> methods.getName() == "show_pathvariable")
+            .findFirst()
+            .orElseThrow(RuntimeException::new);
+
+        Parameter parameter = method.getParameters()[0];
+        ParameterResolver resolver = new PathVariableParameterResolver("/users/{id}");
+
+        assertThat(resolver.support(parameter))
+            .isTrue();
+    }
+    @Test
+    @DisplayName("PathVariableParameter 인수를 가진 요청에 대해 request를 반환합니다.")
+    void returnPathVariableParameter(){
+        final var request = mock(HttpServletRequest.class);
+        final var response = mock(HttpServletResponse.class);
+        when(request.getRequestURI()).thenReturn("/users/12345");
+
+        Method method = Arrays.stream(TestUserController.class.getDeclaredMethods())
+            .filter(methods -> methods.getName() == "show_pathvariable")
+            .findFirst()
+            .orElseThrow(RuntimeException::new);
+
+        Parameter parameter = method.getParameters()[0];
+        ParameterResolver resolver = new PathVariableParameterResolver("/users/{id}");
+
+        assertThat(resolver.parseValue(parameter, request, response))
+            .isEqualTo(12345L);
+    }
+}

--- a/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/TypeArgumentResolverTest.java
+++ b/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/TypeArgumentResolverTest.java
@@ -1,7 +1,6 @@
 package com.interface21.webmvc.servlet.mvc.tobe.parameter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/TypeArgumentResolverTest.java
+++ b/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/parameter/TypeArgumentResolverTest.java
@@ -1,0 +1,74 @@
+package com.interface21.webmvc.servlet.mvc.tobe.parameter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import samples.TestUserController;
+
+class TypeArgumentResolverTest {
+    @Test
+    @DisplayName("PathVariableParameter 지원하는지 확인한다.")
+    void support(){
+        final var request = mock(HttpServletRequest.class);
+        final var response = mock(HttpServletResponse.class);
+
+        Method method = Arrays.stream(TestUserController.class.getDeclaredMethods())
+            .filter(methods -> methods.getName() == "create_int_long")
+            .findFirst()
+            .orElseThrow(RuntimeException::new);
+
+        Parameter parameter = method.getParameters()[0];
+        ParameterResolver resolver = new TypeArgumentResolver();
+
+        assertThat(resolver.support(parameter))
+            .isTrue();
+    }
+    @Test
+    @DisplayName("primitive 인수를 가진 요청에 대해 request를 반환합니다.")
+    void returnPrimitiveParameter(){
+        final var request = mock(HttpServletRequest.class);
+        final var response = mock(HttpServletResponse.class);
+        when(request.getParameter("id")).thenReturn("123");
+        when(request.getParameter("age")).thenReturn("1234");
+
+        Method method = Arrays.stream(TestUserController.class.getDeclaredMethods())
+            .filter(methods -> methods.getName() == "create_int_long")
+            .findFirst()
+            .orElseThrow(RuntimeException::new);
+
+        Parameter parameter = method.getParameters()[0];
+        ParameterResolver resolver = new TypeArgumentResolver();
+
+        assertThat(resolver.parseValue(parameter, request, response))
+            .isEqualTo(123L);
+    }
+
+    @Test
+    @DisplayName("Wrapper 인수를 가진 요청에 대해 request를 반환합니다.")
+    void returnWrapperVariableParameter(){
+        final var request = mock(HttpServletRequest.class);
+        final var response = mock(HttpServletResponse.class);
+        when(request.getParameter("userId")).thenReturn("123");
+        when(request.getParameter("password")).thenReturn("1234");
+
+        Method method = Arrays.stream(TestUserController.class.getDeclaredMethods())
+            .filter(methods -> methods.getName() == "create_string")
+            .findFirst()
+            .orElseThrow(RuntimeException::new);
+
+        Parameter parameter = method.getParameters()[0];
+        ParameterResolver resolver = new TypeArgumentResolver();
+
+        assertThat(resolver.parseValue(parameter, request, response))
+            .isEqualTo("123");
+    }
+}

--- a/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/support/AnnotationHandlerMappingTest.java
+++ b/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/support/AnnotationHandlerMappingTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import com.interface21.webmvc.servlet.mvc.tobe.AnnotationHandlerMapping;
 import com.interface21.webmvc.servlet.mvc.tobe.HandlerExecution;
 import com.interface21.webmvc.servlet.mvc.tobe.exception.NotFoundException;
+import com.interface21.webmvc.servlet.mvc.tobe.parameter.config.ResolverRegistryConfig;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,7 +22,7 @@ class AnnotationHandlerMappingTest {
 
     @BeforeEach
     void setUp() {
-        handlerMapping = new AnnotationHandlerMapping("samples");
+        handlerMapping = new AnnotationHandlerMapping(ResolverRegistryConfig.getResolverRegistry(),"samples");
         handlerMapping.initialize();
     }
 
@@ -77,7 +78,7 @@ class AnnotationHandlerMappingTest {
     void SuppportAllMethodsGivenNoRequestMethod(String method) throws Exception {
 
         AnnotationHandlerMapping handlerMappingNoMethod = new AnnotationHandlerMapping(
-            "samples.badmethod");
+            ResolverRegistryConfig.getResolverRegistry(),"samples.badmethod");
         handlerMappingNoMethod.initialize();
 
         final var request = mock(HttpServletRequest.class);

--- a/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/support/AnnotationHandlerMappingTest.java
+++ b/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/support/AnnotationHandlerMappingTest.java
@@ -67,8 +67,8 @@ class AnnotationHandlerMappingTest {
         when(request.getRequestURI()).thenReturn("/notexistingPath");
         when(request.getMethod()).thenReturn("POST");
 
-        assertThat(handlerMapping.getHandler(request))
-            .isEqualTo(null);
+        assertThatThrownBy(() -> handlerMapping.getHandler(request))
+            .isInstanceOf(NotFoundException.class);
     }
 
 

--- a/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/support/PathPatternParserTest.java
+++ b/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/support/PathPatternParserTest.java
@@ -1,0 +1,26 @@
+package com.interface21.webmvc.servlet.mvc.tobe.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class PathPatternParserTest {
+
+    @ParameterizedTest
+    @CsvSource(value = {
+        "/users/{id},/users/123456",
+        "/users/{id}/products/{productid},/users/123456/products/123456"
+    })
+    @DisplayName("url 패턴에 따른 변수 값들을 가져온다.")
+    void patternPatternParser(String pattern, String url) {
+        PathPatternParser pathPatternParser = new PathPatternParser(pattern);
+        Map<String, String> params = pathPatternParser.extractUriVariables(url);
+
+        assertThat(pathPatternParser.matches(url)).isTrue();
+        assertThat(params).containsKey("id");
+        assertThat(params).containsValues("123456");
+    }
+}

--- a/mvc/src/test/java/samples/TestUser.java
+++ b/mvc/src/test/java/samples/TestUser.java
@@ -1,10 +1,15 @@
 package samples;
 
+import java.util.Objects;
+
 public class TestUser {
 
     private String userId;
     private String password;
     private int age;
+
+    public TestUser() {
+    }
 
     public TestUser(String userId, String password, int age) {
         this.userId = userId;
@@ -31,5 +36,23 @@ public class TestUser {
             ", password='" + password + '\'' +
             ", age=" + age +
             '}';
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        TestUser testUser = (TestUser) object;
+        return age == testUser.age && Objects.equals(userId, testUser.userId)
+            && Objects.equals(password, testUser.password);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userId, password, age);
     }
 }


### PR DESCRIPTION
## 테스트
![image](https://github.com/user-attachments/assets/8da4a579-37d3-4c76-ac32-70fb8ff643f2)


## 요구사항

[x] 학습 테스트를 
[x] Controller 메서드의 인자 타입에 따라 자동 으로 형변환 후 맵핑
    - [x] compilerArgs 옵션을 생성해서 메서드 파라미터를 가져올 수 있게 적용합니다.
    - [x] HandlerMethodArgumentResolver에 기능 추가를 합니다.
        - Resolvers들을 Registry 형태로 생성합니다.
            - primitive type에 대한 지원을 추가합니다.
            - 객체 타입에 대한 지원을 추가합니다.
            - 기본적인 Wrapper class에 대한 지원을 추가합니다.
            - HttpServletRequest와 HttpServletResponse를 지원한다.
    - [x] PathPatternParser를 이용해서 PathVariable 구현을 위한 기능을 추가합니다.
        - 기능
            - URL 매칭과 경로에서 변수를 추출한다.
        - 조건
            - "/users/{id}"
            - "/users/{id}/otherResource/{resourceId}" 와 같은 포맷을 지원한다.
    - [x] Resolver를 MethodMapping 할때, 알맞은 args를 넘겨주도록 사용합니다.

선흠님 이번에도 잘 부탁드리겠습니다!
